### PR TITLE
Upgrade Schematron processor from schxslt to schxslt2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,25 +31,30 @@ against upstream.
 ## Architecture
 
 This is a **Docker-based GitHub Action**, not a JavaScript action, because it
-needs the `jing` (Relax NG) and Java-based `schxslt-cli.jar` (Schematron) tools
+needs the `jing` (Relax NG) and Saxon-HE (Schematron via schxslt2) tools
 installed in the runner. Flow:
 
 1. [action.yml](action.yml) declares `runs.using: docker` pointing at
-   [Dockerfile](Dockerfile). The Dockerfile is multi-stage: stage 1 uses
-   `pnpm run package` to bundle `src/` into `dist/index.js`; stage 2 is the
-   runtime image on `node:26-slim` with `jing` and `schxslt-cli.jar` installed.
-   ENTRYPOINT is `node /usr/src/app/dist/index.js`.
+   [Dockerfile](Dockerfile). The Dockerfile is three-stage:
+   1. **build** — `pnpm run package` bundles `src/` into `dist/index.js`.
+   2. **schemas** — downloads Saxon-HE, xmlresolver, and the schxslt2
+      transpiler; runs the transpiler over every `schemas/dracor_*.sch` to
+      produce a precompiled validator XSLT (`schemas/dracor_*.xsl`).
+   3. **runtime** — `node:26-slim` with `jing` (which transitively pulls in a
+      JRE) plus the Saxon jars + precompiled `.xsl` files. ENTRYPOINT is
+      `node /usr/src/app/dist/index.js`.
 2. [src/index.ts](src/index.ts) → [src/main.ts](src/main.ts) reads inputs via
    `@actions/core`, resolves file paths (glob or space-separated) via
    [src/utils.ts](src/utils.ts), and picks the schema files from the bundled
    [schemas/](schemas/) directory.
 3. Relax NG validation shells out to `jing` and parses its stdout
    (`file:line:col: type: message`).
-4. For the `dracor` schema, [src/schematron.ts](src/schematron.ts) additionally
-   runs `schxslt-cli.jar` per file, parses the SVRL report with
-   `@xmldom/xmldom` + `xpath`, and resolves line/column numbers by re-parsing
-   the source XML with a locator-enabled DOM parser (SVRL only gives XPath
-   locations).
+4. For the `dracor` schema, [src/schematron.ts](src/schematron.ts) invokes
+   Saxon-HE against the precompiled `dracor_<version>.xsl` per file, parses the
+   SVRL report with `@xmldom/xmldom` + `xpath`, and resolves line/column numbers
+   by re-parsing the source XML with a locator-enabled DOM parser (SVRL only
+   gives XPath locations). No Schematron compilation happens at runtime — it all
+   happens in the `schemas` build stage.
 5. Results are aggregated into a GitHub Actions job summary table
    (`core.summary`). Exit non-zero on errors unless `warn-only` is set.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1
 
+ARG SAXON_VERSION=13.0
+ARG XMLRESOLVER_VERSION=6.0.23
+ARG SCHXSLT2_VERSION=1.11.2
+
 # Stage 1: build the bundled action entry point.
 FROM node:26-slim AS build
 WORKDIR /build
@@ -10,18 +14,56 @@ COPY tsconfig.base.json tsconfig.json rolldown.config.ts ./
 COPY src ./src
 RUN pnpm run package
 
-# Stage 2: runtime image.
+# Stage 2: precompile every DraCor Schematron schema to a validator XSLT
+# using the schxslt2 transpiler. Only the compiled `.xsl` outputs move
+# forward into the runtime stage — the transpiler stylesheets stay here.
+FROM debian:bookworm-slim AS schemas
+ARG SAXON_VERSION
+ARG XMLRESOLVER_VERSION
+ARG SCHXSLT2_VERSION
+WORKDIR /work
+# hadolint ignore=DL3008
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+    ca-certificates curl unzip default-jre-headless && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+RUN curl -Lsfo saxon.jar \
+    "https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar" && \
+  curl -Lsfo xmlresolver.jar \
+    "https://repo1.maven.org/maven2/org/xmlresolver/xmlresolver/${XMLRESOLVER_VERSION}/xmlresolver-${XMLRESOLVER_VERSION}.jar" && \
+  curl -Lsfo schxslt2.zip \
+    "https://codeberg.org/SchXslt/schxslt2/releases/download/v${SCHXSLT2_VERSION}/schxslt2-${SCHXSLT2_VERSION}.zip" && \
+  unzip -q schxslt2.zip && \
+  mv "schxslt2-${SCHXSLT2_VERSION}" schxslt2 && \
+  rm schxslt2.zip
+COPY schemas /input
+RUN mkdir -p /output && \
+  for sch in /input/dracor_*.sch; do \
+    name=$(basename "$sch" .sch); \
+    echo "Compiling ${name}.sch"; \
+    java -cp "saxon.jar:xmlresolver.jar" net.sf.saxon.Transform \
+      -s:"$sch" \
+      -xsl:schxslt2/transpile.xsl \
+      -o:"/output/${name}.xsl"; \
+  done
+
+# Stage 3: runtime image.
+# `jing` transitively depends on default-jre, which Saxon also needs, so
+# there's no explicit JRE install here.
 FROM node:26-slim
 WORKDIR /usr/src/app
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends jing curl && \
-  curl -Lsfo ./schxslt-cli.jar https://codeberg.org/SchXslt/schxslt/releases/download/v1.10.1/schxslt-cli.jar && \
+  apt-get install -y --no-install-recommends \
+    ca-certificates jing && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
 COPY schemas ./schemas
+COPY --from=schemas /output/*.xsl ./schemas/
+COPY --from=schemas /work/saxon.jar /work/xmlresolver.jar ./
 COPY --from=build /build/dist ./dist
 
 ENTRYPOINT ["node", "/usr/src/app/dist/index.js"]

--- a/__fixtures__/svrl/report.xml
+++ b/__fixtures__/svrl/report.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                        xmlns:tei="http://www.tei-c.org/ns/1.0">
-  <svrl:active-pattern name="dracor-checks" documents="file:{{DOCUMENT_PATH}}"/>
-  <svrl:fired-rule context="tei:teiHeader" role="warning"/>
-  <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI/Q{http://www.tei-c.org/ns/1.0}teiHeader">
+  <svrl:active-pattern id="schematron-constraint-dracor-checks-1"/>
+  <svrl:fired-rule role="warning"
+                   context="tei:teiHeader"
+                   document="file:{{DOCUMENT_PATH}}"/>
+  <svrl:failed-assert patternId="schematron-constraint-dracor-checks-1"
+                      location="/Q{http://www.tei-c.org/ns/1.0}TEI/Q{http://www.tei-c.org/ns/1.0}teiHeader"
+                      test="@xml:id">
     <svrl:text>Attribute @xml:id missing on element &lt;teiHeader&gt;.</svrl:text>
   </svrl:failed-assert>
-  <svrl:fired-rule context="tei:title"/>
-  <svrl:successful-report location="/Q{http://www.tei-c.org/ns/1.0}TEI/Q{http://www.tei-c.org/ns/1.0}teiHeader/Q{http://www.tei-c.org/ns/1.0}fileDesc/Q{http://www.tei-c.org/ns/1.0}titleStmt/Q{http://www.tei-c.org/ns/1.0}title">
+  <svrl:fired-rule context="tei:title"
+                   document="file:{{DOCUMENT_PATH}}"/>
+  <svrl:successful-report patternId="schematron-constraint-dracor-checks-1"
+                          location="/Q{http://www.tei-c.org/ns/1.0}TEI/Q{http://www.tei-c.org/ns/1.0}teiHeader/Q{http://www.tei-c.org/ns/1.0}fileDesc/Q{http://www.tei-c.org/ns/1.0}titleStmt/Q{http://www.tei-c.org/ns/1.0}title"
+                          test="true()">
     <svrl:text>Second issue on same document exercises the doc cache.</svrl:text>
   </svrl:successful-report>
 </svrl:schematron-output>

--- a/__tests__/schematron.test.ts
+++ b/__tests__/schematron.test.ts
@@ -61,22 +61,24 @@ describe('schematron.ts', () => {
   });
 
   describe('runSchxslt', () => {
-    it('invokes java with expected arguments and returns a report path', async () => {
+    it('invokes Saxon on a precompiled validator XSLT and returns a report path', async () => {
       exec.exec.mockImplementation(async () => 0);
-      const reportFile = await runSchxslt('in.xml', 'schema.sch', 'my-jar.jar');
+      const reportFile = await runSchxslt(
+        'in.xml',
+        'validator.xsl',
+        'saxon.jar:xmlresolver.jar'
+      );
 
       expect(exec.exec).toHaveBeenCalledTimes(1);
       const [cmd, args] = exec.exec.mock.calls[0];
       expect(cmd).toBe('java');
       expect(args).toEqual([
-        '-jar',
-        'my-jar.jar',
-        '-d',
-        'in.xml',
-        '-s',
-        'schema.sch',
-        '-o',
-        reportFile,
+        '-cp',
+        'saxon.jar:xmlresolver.jar',
+        'net.sf.saxon.Transform',
+        '-s:in.xml',
+        '-xsl:validator.xsl',
+        `-o:${reportFile}`,
       ]);
       expect(reportFile).toMatch(/svrl\.xml$/);
     });
@@ -85,16 +87,16 @@ describe('schematron.ts', () => {
       exec.exec.mockImplementation(async () => {
         throw new Error('boom');
       });
-      const reportFile = await runSchxslt('in.xml', 'schema.sch');
+      const reportFile = await runSchxslt('in.xml', 'validator.xsl');
       expect(reportFile).toMatch(/svrl\.xml$/);
     });
   });
 
   describe('validate', () => {
-    it('runs schxslt and returns parsed asserts', async () => {
+    it('runs Saxon on the compiled validator and returns parsed asserts', async () => {
       exec.exec.mockImplementation(async (_cmd, args) => {
-        const outIdx = (args as string[]).indexOf('-o');
-        const outFile = (args as string[])[outIdx + 1];
+        const outArg = (args as string[]).find((a) => a.startsWith('-o:'));
+        const outFile = outArg!.slice(3);
         writeFileSync(
           outFile,
           svrlTemplate.replaceAll('{{DOCUMENT_PATH}}', samplePath)
@@ -102,7 +104,7 @@ describe('schematron.ts', () => {
         return 0;
       });
 
-      const results = await validate('in.xml', 'schema.sch', 'jar.jar');
+      const results = await validate('in.xml', 'validator.xsl', 'saxon.jar');
       expect(results).toHaveLength(2);
       expect(results[0].fileName).toBe('sample.xml');
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,14 +56,16 @@ export async function run(): Promise<void> {
     const schemaDir = join(dirname(import.meta.dirname), 'schemas');
     core.debug(`schemaDir '${schemaDir}'`);
 
-    let schemaTitle, rngFileName, schematronFileName;
+    let schemaTitle, rngFileName, schematronXslFileName;
     if (schema === 'tei') {
       schemaTitle = `TEI-All ${version}`;
       rngFileName = `tei_all_${version}.rng`;
     } else if (schema === 'dracor') {
       schemaTitle = `DraCor Schema ${version}`;
       rngFileName = `dracor_${version}.rng`;
-      schematronFileName = `dracor_${version}.sch`;
+      // Precompiled at Docker build time from `dracor_${version}.sch` using
+      // the schxslt2 transpiler.
+      schematronXslFileName = `dracor_${version}.xsl`;
     } else {
       throw new Error(`Unknown schema "${schema}"`);
     }
@@ -72,7 +74,7 @@ export async function run(): Promise<void> {
     core.debug(`schemaTitle '${schemaTitle}'`);
     core.debug(`rngFileName '${rngFileName}'`);
     core.debug(`rngFile '${rngFile}'`);
-    core.debug(`schematronFileName '${schematronFileName}'`);
+    core.debug(`schematronXslFileName '${schematronXslFileName}'`);
 
     core.summary.addHeading(`Validation against ${schemaTitle}`, '2');
 
@@ -119,11 +121,11 @@ export async function run(): Promise<void> {
         }
       });
 
-      if (schematronFileName) {
-        const schematronFile = join(schemaDir, schematronFileName);
-        const jar = '/usr/src/app/schxslt-cli.jar';
+      if (schematronXslFileName) {
+        const validatorXsl = join(schemaDir, schematronXslFileName);
+        const classpath = '/usr/src/app/saxon.jar:/usr/src/app/xmlresolver.jar';
         for (const f of filePaths) {
-          const asserts = await validate(f, schematronFile, jar);
+          const asserts = await validate(f, validatorXsl, classpath);
           asserts.forEach(
             ({ document, role, text, lineNumber = 0, columnNumber = 0 }) => {
               // for now we skip informational messages

--- a/src/schematron.ts
+++ b/src/schematron.ts
@@ -19,56 +19,55 @@ export interface SchematronAssert {
 }
 
 /**
- * Validate XML file using the Schxslt schematron processor.
+ * Validate an XML file against a Schematron rule set.
  *
- * This function expects the Schxslt CLI JAR file to be in the current working
- * directory. Alternatively the path to the JAR can be passed in as the third
- * argument.
+ * Under schxslt2 the compilation step (Schematron → validator XSLT) is done
+ * ahead of time at Docker build time, so at runtime we only need to apply
+ * a compiled validator XSLT to the input document. The XSLT is executed by
+ * Saxon-HE.
  *
  * @param inputFile XML file to validate
- * @param schema Schematron file
- * @param jar Path to the schxslt-cli.jar
+ * @param validatorXsl Precompiled validator XSLT (produced by schxslt2 at
+ *   image build time from the corresponding `.sch` file)
+ * @param classpath Java classpath containing Saxon-HE and its runtime
+ *   dependencies (e.g. xmlresolver)
  * @returns Array of assert objects.
  */
 export async function validate(
   inputFile: string,
-  schema: string,
-  jar: string = 'schxslt-cli.jar'
+  validatorXsl: string,
+  classpath: string = 'saxon.jar'
 ): Promise<SchematronAssert[]> {
-  const report = await runSchxslt(inputFile, schema, jar);
+  const report = await runSchxslt(inputFile, validatorXsl, classpath);
   core.debug(report);
   return parseSVRL(report);
 }
 
 /**
- * Run Schxslt schematron processor on input file with given schema.
- *
- * This function expects the Schxslt CLI JAR file to be in the current working
- * directory. Alternatively the path to the JAR can be passed in as the third
- * argument.
+ * Apply a precompiled Schematron validator XSLT to `inputFile` via Saxon-HE
+ * and return the path to the resulting SVRL report.
  *
  * @param inputFile XML file to validate
- * @param schema Schematron file
- * @param jar Path to the schxslt-cli.jar
+ * @param validatorXsl Precompiled validator XSLT
+ * @param classpath Java classpath containing Saxon-HE and its runtime
+ *   dependencies
  * @returns Path to SVRL file.
  */
 export async function runSchxslt(
   inputFile: string,
-  schema: string,
-  jar: string = 'schxslt-cli.jar'
+  validatorXsl: string,
+  classpath: string = 'saxon.jar'
 ): Promise<string> {
   const dir = mkdtempSync(join(tmpdir(), 'report-'));
   const reportFile = join(dir, 'svrl.xml');
   try {
     await exec('java', [
-      '-jar',
-      jar,
-      '-d',
-      inputFile,
-      '-s',
-      schema,
-      '-o',
-      reportFile,
+      '-cp',
+      classpath,
+      'net.sf.saxon.Transform',
+      `-s:${inputFile}`,
+      `-xsl:${validatorXsl}`,
+      `-o:${reportFile}`,
     ]);
     core.debug(`schxslt ran successful on ${inputFile}`);
   } catch (error) {
@@ -96,7 +95,7 @@ function getDoc(path: string) {
  * Read an SVRL report, extract asserts and determine line and column numbers.
  *
  * @param file Report file in SVRL format
- * @returns Path to SVRL file.
+ * @returns Array of assert objects.
  */
 export function parseSVRL(file: string): SchematronAssert[] {
   const reportXML = readFileSync(file, 'utf8');
@@ -127,25 +126,28 @@ export function parseSVRL(file: string): SchematronAssert[] {
       'tei:'
     );
 
+    // schxslt2 places @role, @context, and @document on the preceding
+    // fired-rule. patternName comes back-referenced on the assertion
+    // itself via @patternId (schxslt2 addition; strip the boilerplate
+    // "schematron-constraint-" prefix and the trailing "-<n>" suffix).
     const [rule] = select(
       'preceding-sibling::svrl:fired-rule[1]',
       assert
     ) as Node[];
     const context = select('string(@context)', rule) as string;
     const role = select('string(@role)', rule) as string;
-    const [pattern] = select(
-      'preceding-sibling::svrl:active-pattern[1]',
-      assert
-    ) as Node[];
-    const patternName = select('string(@name)', pattern) as string;
-    const document = (select('string(@documents)', pattern) as string).replace(
+    const document = (select('string(@document)', rule) as string).replace(
       /^file:/,
       ''
     );
+    const patternName = (select('string(@patternId)', assert) as string)
+      .replace(/^schematron-constraint-/, '')
+      .replace(/-\d+$/, '');
+
     const doc = getDoc(document);
     // @ts-expect-error figure out how to type node
     const [node] = select(location, doc);
-    const { lineNumber, columnNumber } = node;
+    const { lineNumber, columnNumber } = node ?? {};
     const fileName = basename(document);
     results.push({
       text: text


### PR DESCRIPTION
Closes #116.

Prototype swap from schxslt (maintenance-mode) to [schxslt2](https://codeberg.org/SchXslt/schxslt2).

## Approach

`schxslt2` is distributed as a set of XSLT stylesheets, not a CLI jar, so we bring our own XSLT 3.0 processor (Saxon-HE) and drive the two steps ourselves. Rather than compiling the DraCor Schematron files at runtime for every action invocation, the Dockerfile precompiles all `schemas/dracor_*.sch` files at image build time — validating a file at runtime becomes a single Saxon invocation against the corresponding `dracor_${version}.xsl`.

## Component versions (pinned via Dockerfile ARGs)

- Saxon-HE 13.0
- xmlresolver 6.0.23 (mandatory classpath dep of Saxon 12+)
- schxslt2 1.11.2

## Runtime invocation

```
java -cp saxon.jar:xmlresolver.jar net.sf.saxon.Transform \
  -s:INPUT.xml \
  -xsl:schemas/dracor_${VERSION}.xsl \
  -o:REPORT.svrl
```

## SVRL layout differences we adapted to

The schxslt2 SVRL keeps the v1 shape overall, but has three deltas that `parseSVRL` had to accommodate:

1. `fired-rule/@document` (singular, on `fired-rule`) instead of `active-pattern/@documents` (plural, on `active-pattern`).
2. `active-pattern` no longer carries `@name` — schxslt2 instead adds `@patternId` as a back-reference on `failed-assert` / `successful-report`. We derive `patternName` from that, stripping the boilerplate `schematron-constraint-` prefix and trailing `-N` suffix.
3. `@role` and `@context` still live on the preceding `fired-rule`, same as v1.

## Test plan

- [x] `pnpm run all` passes (36 tests, coverage stable, bundle built).
- [x] `docker build` completes; multi-stage builds all 9 DraCor validator XSLTs and copies them into the runtime image.
- [x] `docker run` against `tei/valid.xml` with `INPUT_SCHEMA=dracor` reports the expected 4 warnings at correct line/col numbers (`19:7`, `20:9` twice, `50:5`), 0 errors — matching pre-upgrade behavior.
- [x] CI docker + action jobs pass on GHA runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
