### PR TITLE
Stop deep-importing SummaryTableRow from @actions/core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Typecheck
+        run: pnpm run typecheck
+
       - name: Test
         run: pnpm run ci-test
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "package": "rolldown -c rolldown.config.ts",
     "package:watch": "pnpm run package -- --watch",
     "test": "vitest run",
-    "all": "pnpm run format:write && pnpm run lint && pnpm run ci-test && pnpm run coverage && pnpm run package"
+    "typecheck": "tsc --noEmit",
+    "all": "pnpm run format:write && pnpm run lint && pnpm run typecheck && pnpm run ci-test && pnpm run coverage && pnpm run package"
   },
   "dependencies": {
     "@actions/core": "^3.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core';
 import { exec, ExecOptions } from '@actions/exec';
 import { dirname, join } from 'path';
-import { SummaryTableRow } from '@actions/core/lib/summary.js';
 import {
   getParams,
   makeLink,
@@ -18,6 +17,14 @@ interface ValidationError {
   lineNumber: number;
   columnNumber: number;
 }
+
+// Structural copy of @actions/core's SummaryTableRow. That type lives in
+// @actions/core/lib/summary.js which is walled off by the package's
+// `exports` field starting in v3, so we can't import it directly.
+type SummaryTableCell =
+  | string
+  | { data: string; header?: boolean; colspan?: string; rowspan?: string };
+type SummaryTableRow = SummaryTableCell[];
 
 const ERRLIMIT = 1000;
 


### PR DESCRIPTION
## Summary

- `@actions/core@3` added an `exports` field that walls off deep imports, so `import { SummaryTableRow } from '@actions/core/lib/summary.js'` no longer resolves under TypeScript. Rolldown was more permissive and still bundled the module by path, which is why nothing broke at runtime and CI stayed green — `pnpm run all` did not include a typecheck step.
- Replace the deep import with a small local structural alias in [src/main.ts](src/main.ts).
- Add a `typecheck` npm script (`tsc --noEmit`) and run it from both `pnpm run all` and CI so this class of bug gets caught next time.

## Test plan

- [x] `pnpm run typecheck` clean.
- [x] `pnpm run all` green (36 tests, coverage stable, bundle built).
- [x] CI's new `Typecheck` step passes on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
