### PR TITLE
Bump @xmldom/xmldom, @actions/exec, @actions/glob to latest majors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   },
   "dependencies": {
     "@actions/core": "^3.0.1",
-    "@actions/exec": "^2.0.0",
+    "@actions/exec": "^3.0.0",
     "@actions/github": "^9.1.1",
-    "@actions/glob": "^0.5.1",
-    "@xmldom/xmldom": "^0.8.11",
+    "@actions/glob": "^0.7.0",
+    "@xmldom/xmldom": "^0.9.11",
     "xpath": "^0.0.34"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,17 +11,17 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       "@actions/exec":
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.0
+        version: 3.0.0
       "@actions/github":
         specifier: ^9.1.1
         version: 9.1.1
       "@actions/glob":
-        specifier: ^0.5.1
-        version: 0.5.1
+        specifier: ^0.7.0
+        version: 0.7.0
       "@xmldom/xmldom":
-        specifier: ^0.8.11
-        version: 0.8.14
+        specifier: ^0.9.11
+        version: 0.9.11
       xpath:
         specifier: ^0.0.34
         version: 0.0.34
@@ -85,22 +85,10 @@ importers:
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0))
 
 packages:
-  "@actions/core@2.0.3":
-    resolution:
-      {
-        integrity: sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==,
-      }
-
   "@actions/core@3.0.1":
     resolution:
       {
         integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==,
-      }
-
-  "@actions/exec@2.0.0":
-    resolution:
-      {
-        integrity: sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==,
       }
 
   "@actions/exec@3.0.0":
@@ -115,10 +103,10 @@ packages:
         integrity: sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==,
       }
 
-  "@actions/glob@0.5.1":
+  "@actions/glob@0.7.0":
     resolution:
       {
-        integrity: sha512-+dv/t2aKQdKp9WWSp+1yIXVJzH5Q38M0Mta26pzIbeec14EcIleMB7UU6N7sNgbEuYfyuVGpE5pOKjl6j1WXkA==,
+        integrity: sha512-+7s3wM+cXapDLmLL1NVWHawqcJOZzXZy2df/VhNn8DnZtS/x83iTCKaUn9F0llur4h3CII0AilvKKH4CMPL8Gw==,
       }
 
   "@actions/http-client@3.0.2":
@@ -131,12 +119,6 @@ packages:
     resolution:
       {
         integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==,
-      }
-
-  "@actions/io@2.0.0":
-    resolution:
-      {
-        integrity: sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==,
       }
 
   "@actions/io@3.0.2":
@@ -1100,12 +1082,12 @@ packages:
         integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==,
       }
 
-  "@xmldom/xmldom@0.8.14":
+  "@xmldom/xmldom@0.9.11":
     resolution:
       {
-        integrity: sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==,
+        integrity: sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==,
       }
-    engines: { node: ">=10.0.0" }
+    engines: { node: ">=14.6" }
 
   acorn-jsx@5.3.2:
     resolution:
@@ -3553,19 +3535,10 @@ packages:
     engines: { node: ">=10" }
 
 snapshots:
-  "@actions/core@2.0.3":
-    dependencies:
-      "@actions/exec": 2.0.0
-      "@actions/http-client": 3.0.2
-
   "@actions/core@3.0.1":
     dependencies:
       "@actions/exec": 3.0.0
       "@actions/http-client": 4.0.1
-
-  "@actions/exec@2.0.0":
-    dependencies:
-      "@actions/io": 2.0.0
 
   "@actions/exec@3.0.0":
     dependencies:
@@ -3581,10 +3554,10 @@ snapshots:
       "@octokit/request-error": 7.1.1
       undici: 6.28.0
 
-  "@actions/glob@0.5.1":
+  "@actions/glob@0.7.0":
     dependencies:
-      "@actions/core": 2.0.3
-      minimatch: 3.1.5
+      "@actions/core": 3.0.1
+      minimatch: 10.2.6
 
   "@actions/http-client@3.0.2":
     dependencies:
@@ -3595,8 +3568,6 @@ snapshots:
     dependencies:
       tunnel: 0.0.6
       undici: 6.28.0
-
-  "@actions/io@2.0.0": {}
 
   "@actions/io@3.0.2": {}
 
@@ -4162,7 +4133,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  "@xmldom/xmldom@0.8.14": {}
+  "@xmldom/xmldom@0.9.11": {}
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:

--- a/src/schematron.ts
+++ b/src/schematron.ts
@@ -84,7 +84,10 @@ function getDoc(path: string) {
     return teiDocs[path];
   }
   const xml = readFileSync(path, 'utf8');
-  const doc = new DOMParser({ locator: {} }).parseFromString(xml);
+  const doc = new DOMParser({ locator: true }).parseFromString(
+    xml,
+    'text/xml'
+  ) as unknown as Document;
   teiDocs[path] = doc;
   return doc;
 }
@@ -98,14 +101,12 @@ function getDoc(path: string) {
 export function parseSVRL(file: string): SchematronAssert[] {
   const reportXML = readFileSync(file, 'utf8');
   const reportDoc = new DOMParser({
-    errorHandler: {
-      warning: function () {},
-      error: function () {},
-      fatalError: function (e) {
-        console.error(e);
-      },
+    onError: (level, message) => {
+      if (level === 'fatalError') {
+        console.error(message);
+      }
     },
-  }).parseFromString(reportXML);
+  }).parseFromString(reportXML, 'text/xml') as unknown as Node;
 
   const select = xpath.useNamespaces({
     svrl: 'http://purl.oclc.org/dsdl/svrl',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { relative } from 'path';
 import * as core from '@actions/core';
-import glob from '@actions/glob';
+import * as glob from '@actions/glob';
 import { DRACOR_VERSION, TEI_VERSION } from './config.js';
 
 export interface Params {


### PR DESCRIPTION
## Summary

Bumps three deps to their latest majors. Each required small code adjustments; the newly added `typecheck` step in `pnpm run all` (from #145) caught them cleanly.

- **`@xmldom/xmldom` 0.8.14 → 0.9.11**
  - `parseFromString` now requires an explicit `mimeType` argument (`'text/xml'`).
  - `locator` option is `boolean` instead of a truthy object.
  - `errorHandler` (object with `warning`/`error`/`fatalError` callbacks) was replaced by `onError(level, message)`.
  - The returned `Document` type no longer extends the DOM lib's `Node`, so `xpath.select` calls in [src/schematron.ts](src/schematron.ts) cast through `unknown as Node`.
- **`@actions/exec` 2.0.0 → 3.0.0** — no surface changes for our callers (we only use `exec()` with the listeners shape).
- **`@actions/glob` 0.5.1 → 0.7.0** — dropped default export; switched to `import * as glob from '@actions/glob'` in [src/utils.ts](src/utils.ts).

## Test plan

- [x] `pnpm run all` green (36 tests, coverage stable, typecheck clean, bundle built).
- [x] Runtime smoke test of the bundled action against `tei/valid.xml` (0 issues) and `tei/invalid.xml` (2 errors reported at correct line/col).
- [ ] CI green on this PR (typecheck, ci-test, test-docker, test-action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
