### PR TITLE
Render plain-text summary for local (non-workflow) usage

### DIFF
--- a/__tests__/textSummary.test.ts
+++ b/__tests__/textSummary.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { formatTextSummary } from '../src/textSummary.js';
+
+describe('formatTextSummary', () => {
+  it('renders title, underlined heading, indented stats and no table when there are no issues', () => {
+    const out = formatTextSummary(
+      'TEI-All 4.12.0',
+      ['Total files validated: 1', 'Files with issues: 0'],
+      []
+    );
+    expect(out).toBe(
+      [
+        'TEI-All 4.12.0',
+        '==============',
+        '',
+        '  Total files validated: 1',
+        '  Files with issues: 0',
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('renders an aligned table when there are issues and strips HTML markup', () => {
+    const out = formatTextSummary(
+      'DraCor Schema 1.6.0',
+      ['Total files validated: 1', 'Errors: 1'],
+      [
+        {
+          file: 'valid.xml',
+          lineNumber: 19,
+          columnNumber: 7,
+          type: 'warning',
+          message:
+            'Nesting <code>digital</code> and original source is &lt;deprecated&gt;.',
+        },
+        {
+          file: 'valid.xml',
+          lineNumber: 20,
+          columnNumber: 9,
+          type: 'error',
+          message:
+            '<small>The digital source should use a &lt;ref&gt;.</small>',
+        },
+      ]
+    );
+
+    const lines = out.split('\n');
+
+    // Title + underline
+    expect(lines[0]).toBe('DraCor Schema 1.6.0');
+    expect(lines[1]).toBe('==='.repeat(19 / 3 + 1).slice(0, 19));
+
+    // Header row present with the four expected columns.
+    const header = lines.find((l) => l.startsWith('File'));
+    expect(header).toMatch(/^File\s+Line:Col\s+Type\s+Message$/);
+
+    // Both issue rows present, HTML stripped, entities decoded.
+    expect(out).toContain(
+      'Nesting digital and original source is <deprecated>.'
+    );
+    expect(out).toContain('The digital source should use a <ref>.');
+    expect(out).not.toContain('<code>');
+    expect(out).not.toContain('<small>');
+    expect(out).not.toContain('&lt;');
+
+    // Line:Col column is aligned to the widest value ("Line:Col" = 8 chars).
+    // Both entries "19:7" and "20:9" are shorter, so they must be padded.
+    const dataRows = lines.filter((l) => l.startsWith('valid.xml'));
+    expect(dataRows).toHaveLength(2);
+    for (const row of dataRows) {
+      // File column is padded to the width of "valid.xml" (9) — no extra pad needed here.
+      // Assert the separator between columns is exactly two spaces.
+      expect(row).toMatch(/^valid\.xml {2}\d+:\d+\s+(warning|error)\s+.+$/);
+    }
+  });
+
+  it('falls back to "error" when the issue type is empty', () => {
+    const out = formatTextSummary(
+      'DraCor Schema 1.6.0',
+      ['Errors: 1'],
+      [
+        {
+          file: 'a.xml',
+          lineNumber: 1,
+          columnNumber: 1,
+          type: '',
+          message: 'boom',
+        },
+      ]
+    );
+    expect(out).toMatch(/a\.xml\s+1:1\s+error\s+boom/);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
   truncateJingMessage,
 } from './utils.js';
 import { validate } from './schematron.js';
+import { formatTextSummary } from './textSummary.js';
 
 interface ValidationError {
   message: string;
@@ -80,6 +81,7 @@ export async function run(): Promise<void> {
 
     let jingOutput = '';
     const issues: ValidationError[] = [];
+    const stats: string[] = [];
 
     const options: ExecOptions = {
       listeners: {
@@ -156,10 +158,10 @@ export async function run(): Promise<void> {
         (e) => e.type === 'error' || e.type === 'fatal'
       ).length;
       numWarnings = issues.filter((e) => e.type === 'warning').length;
-      const stats = [
+      stats.push(
         `Total files validated: ${filePaths.length}`,
-        `Files with issues: ${uniqueFiles.length}`,
-      ];
+        `Files with issues: ${uniqueFiles.length}`
+      );
       if (issues.length > 0) {
         stats.push(
           `Total number of issues: ${issues.length}`,
@@ -184,12 +186,16 @@ export async function run(): Promise<void> {
     }
 
     try {
-      // if $GITHUB_STEP_SUMMARY is set we try to write otherwise we dump the
-      // summary to the console
+      // If we're running inside a GitHub workflow, write the HTML summary to
+      // $GITHUB_STEP_SUMMARY so it renders in the Actions UI. Otherwise
+      // (local `docker run` / `./validate`) print a plain-text rendering to
+      // stdout — the HTML summary is only noise on a terminal.
       if (process.env.GITHUB_STEP_SUMMARY) {
         core.summary.write();
+      } else if (filePaths.length) {
+        console.log(formatTextSummary(schemaTitle, stats, issues));
       } else {
-        console.log(core.summary.stringify());
+        console.log(`No files found. ('${files}')`);
       }
     } catch (error) {
       console.log(error);

--- a/src/textSummary.ts
+++ b/src/textSummary.ts
@@ -1,0 +1,74 @@
+export interface TextSummaryIssue {
+  file: string;
+  lineNumber: number;
+  columnNumber: number;
+  type: string;
+  message: string;
+}
+
+/**
+ * Render the validation summary as plain text for local `docker run` /
+ * `./validate` usage where `GITHUB_STEP_SUMMARY` isn't set and the HTML
+ * summary would only be noise.
+ */
+export function formatTextSummary(
+  title: string,
+  stats: string[],
+  issues: TextSummaryIssue[]
+): string {
+  const lines: string[] = [];
+  lines.push(title);
+  lines.push('='.repeat(title.length));
+  lines.push('');
+
+  for (const s of stats) {
+    lines.push(`  ${s}`);
+  }
+
+  if (issues.length === 0) {
+    return lines.join('\n') + '\n';
+  }
+
+  const header = ['File', 'Line:Col', 'Type', 'Message'];
+  const rows = issues.map((i) => [
+    i.file,
+    `${i.lineNumber}:${i.columnNumber}`,
+    i.type || 'error',
+    stripHtml(i.message),
+  ]);
+
+  const widths = [0, 1, 2].map((c) =>
+    Math.max(header[c].length, ...rows.map((r) => r[c].length))
+  );
+
+  const pad = (s: string, w: number) => s + ' '.repeat(w - s.length);
+  const fmt = (row: string[]) =>
+    [
+      pad(row[0], widths[0]),
+      pad(row[1], widths[1]),
+      pad(row[2], widths[2]),
+      row[3],
+    ].join('  ');
+
+  lines.push('');
+  lines.push(fmt(header));
+  lines.push(fmt(widths.map((w) => '-'.repeat(w)).concat('-'.repeat(20))));
+  for (const row of rows) {
+    lines.push(fmt(row));
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Strip the small subset of HTML markup that main.ts / parseSVRL leave in
+ * the message strings (`<code>`, `<small>`, and HTML entities). Not a
+ * general-purpose HTML sanitizer.
+ */
+function stripHtml(s: string): string {
+  return s
+    .replace(/<\/?(code|small|a[^>]*)>/g, '')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
+}


### PR DESCRIPTION
## Summary

When `GITHUB_STEP_SUMMARY` isn't set (local `docker run` or `./validate`), dumping the raw HTML summary to stdout is just noise. This PR renders a small plain-text version instead, consuming the same in-memory data (`schemaTitle`, `stats`, `issues`) the HTML summary is built from.

- New helper [src/textSummary.ts](src/textSummary.ts) with a `formatTextSummary(title, stats, issues)` function — title with underline, indented stats, aligned-column table of issues.
- `main.ts` picks the renderer based on `GITHUB_STEP_SUMMARY`: set → `core.summary.write()` (unchanged behavior in a GitHub workflow), unset → text renderer.
- `stats` array is hoisted so it's reachable from the print step.
- Vitest coverage in [__tests__/textSummary.test.ts](__tests__/textSummary.test.ts): empty-issues case, aligned-table with HTML stripping / entity decoding, empty-type fallback.

## Sample output

For `tei/invalid.xml` under the TEI schema:

```
TEI-All 4.12.0
==============

  Total files validated: 1
  Files with issues: 1
  Total number of issues: 2
  Unique issues: 2
  Errors: 2
  Warnings: 0

File             Line:Col  Type   Message
---------------  --------  -----  --------------------
tei/invalid.xml  10:36     error  attribute "quux" not allowed here; …
tei/invalid.xml  60:8      error  element "foo" not allowed anywhere; …
```

## Known limitations

- **HTML stripping is minimal** — the renderer only unwraps `<code>`, `<small>`, and `<a>` tags because those are the only markup [src/schematron.ts](src/schematron.ts) and jing-message handling actually emit. Not a general-purpose sanitizer.
- **No column truncation** — long jing messages spill past the terminal width. Trivial to add a `--max-col` if that ever becomes annoying.

## Test plan

- [x] `pnpm run all` green (39 tests, coverage stable, typecheck clean, bundle built).
- [x] Runtime smoke test of the bundled action against `tei/valid.xml` (0 issues, no table) and `tei/invalid.xml` (2 errors, aligned table).
- [x] Behavior in a GitHub workflow unchanged (GITHUB_STEP_SUMMARY still receives the HTML summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
