### PR TITLE
Split validation output into separate Errors and Warnings tables

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -109,7 +109,7 @@ describe('main.ts', () => {
     }
   });
 
-  it('adds schematron warnings and errors to the summary table, skipping information', async () => {
+  it('adds schematron warnings and errors to separate summary tables, skipping information', async () => {
     validate.mockResolvedValue([
       {
         document: 'tei/valid.xml',
@@ -134,11 +134,41 @@ describe('main.ts', () => {
       },
     ]);
     await run();
-    expect(core.summary.addTable).toHaveBeenCalled();
-    const table = core.summary.addTable.mock.calls[0][0];
-    // header row + warning + error rows (info skipped)
-    expect(table).toHaveLength(3);
+    // Two tables: errors first, warnings second (info skipped).
+    expect(core.summary.addTable).toHaveBeenCalledTimes(2);
+    const errorTable = core.summary.addTable.mock.calls[0][0];
+    const warningTable = core.summary.addTable.mock.calls[1][0];
+    // header + 1 error row
+    expect(errorTable).toHaveLength(2);
+    // header + 1 warning row
+    expect(warningTable).toHaveLength(2);
+    // Headings emitted for each section.
+    const headings = core.summary.addHeading.mock.calls.map(
+      (c: unknown[]) => c[0]
+    );
+    expect(headings).toContain('Errors');
+    expect(headings).toContain('Warnings');
     // errors present, so action fails
     expect(core.setFailed).toHaveBeenCalledWith('Invalid documents');
+  });
+
+  it('truncates the summary and adds a note when total issues exceed the limit', async () => {
+    // 1001 error rows via schematron > ERRLIMIT (1000)
+    const asserts = Array.from({ length: 1001 }, (_, i) => ({
+      document: 'tei/valid.xml',
+      role: '',
+      text: `err ${i}`,
+      lineNumber: i + 1,
+      columnNumber: 1,
+    }));
+    validate.mockResolvedValue(asserts);
+    await run();
+    const errorTable = core.summary.addTable.mock.calls[0][0];
+    // header + 1000 rows (capped)
+    expect(errorTable).toHaveLength(1001);
+    const rawCalls = core.summary.addRaw.mock.calls.map(
+      (c: unknown[]) => c[0] as string
+    );
+    expect(rawCalls.some((s: string) => /truncated/i.test(s))).toBe(true);
   });
 });

--- a/__tests__/textSummary.test.ts
+++ b/__tests__/textSummary.test.ts
@@ -20,10 +20,10 @@ describe('formatTextSummary', () => {
     );
   });
 
-  it('renders an aligned table when there are issues and strips HTML markup', () => {
+  it('renders separate Errors and Warnings tables, strips HTML markup', () => {
     const out = formatTextSummary(
       'DraCor Schema 1.6.0',
-      ['Total files validated: 1', 'Errors: 1'],
+      ['Total files validated: 1', 'Errors: 1', 'Warnings: 1'],
       [
         {
           file: 'valid.xml',
@@ -50,9 +50,17 @@ describe('formatTextSummary', () => {
     expect(lines[0]).toBe('DraCor Schema 1.6.0');
     expect(lines[1]).toBe('==='.repeat(19 / 3 + 1).slice(0, 19));
 
-    // Header row present with the four expected columns.
-    const header = lines.find((l) => l.startsWith('File'));
-    expect(header).toMatch(/^File\s+Line:Col\s+Type\s+Message$/);
+    // Both section headings emitted, Errors before Warnings.
+    const errorHeadingIdx = lines.indexOf('Errors');
+    const warningHeadingIdx = lines.indexOf('Warnings');
+    expect(errorHeadingIdx).toBeGreaterThan(-1);
+    expect(warningHeadingIdx).toBeGreaterThan(errorHeadingIdx);
+
+    // Header row present, no Type column.
+    const headerRows = lines.filter((l) =>
+      /^File\s+Line:Col\s+Message$/.test(l)
+    );
+    expect(headerRows).toHaveLength(2);
 
     // Both issue rows present, HTML stripped, entities decoded.
     expect(out).toContain(
@@ -63,18 +71,24 @@ describe('formatTextSummary', () => {
     expect(out).not.toContain('<small>');
     expect(out).not.toContain('&lt;');
 
-    // Line:Col column is aligned to the widest value ("Line:Col" = 8 chars).
-    // Both entries "19:7" and "20:9" are shorter, so they must be padded.
+    // Data rows: three-column layout without a type cell.
     const dataRows = lines.filter((l) => l.startsWith('valid.xml'));
     expect(dataRows).toHaveLength(2);
     for (const row of dataRows) {
-      // File column is padded to the width of "valid.xml" (9) — no extra pad needed here.
-      // Assert the separator between columns is exactly two spaces.
-      expect(row).toMatch(/^valid\.xml {2}\d+:\d+\s+(warning|error)\s+.+$/);
+      expect(row).toMatch(/^valid\.xml {2}\d+:\d+\s+.+$/);
     }
+
+    // Error row lands under the Errors heading, warning under Warnings.
+    const errorRowIdx = lines.findIndex((l) =>
+      l.includes('should use a <ref>')
+    );
+    const warningRowIdx = lines.findIndex((l) => l.includes('is <deprecated>'));
+    expect(errorRowIdx).toBeGreaterThan(errorHeadingIdx);
+    expect(errorRowIdx).toBeLessThan(warningHeadingIdx);
+    expect(warningRowIdx).toBeGreaterThan(warningHeadingIdx);
   });
 
-  it('falls back to "error" when the issue type is empty', () => {
+  it('treats an empty issue type as an error', () => {
     const out = formatTextSummary(
       'DraCor Schema 1.6.0',
       ['Errors: 1'],
@@ -88,6 +102,8 @@ describe('formatTextSummary', () => {
         },
       ]
     );
-    expect(out).toMatch(/a\.xml\s+1:1\s+error\s+boom/);
+    expect(out).toContain('Errors');
+    expect(out).not.toContain('Warnings');
+    expect(out).toMatch(/a\.xml\s+1:1\s+boom/);
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,6 +102,7 @@ export async function run(): Promise<void> {
       }
 
       const errorRows: SummaryTableRow[] = [];
+      const warningRows: SummaryTableRow[] = [];
 
       jingOutput.split('\n').forEach((line) => {
         const m = line.match(/^([^:]+):([0-9]+):([0-9]+): ([^:]+): (.+)$/);
@@ -112,12 +113,16 @@ export async function run(): Promise<void> {
           const type = m[4];
           const message = m[5];
           issues.push({ file, lineNumber, columnNumber, type, message });
-          errorRows.push([
+          const row: SummaryTableRow = [
             makeLink(file, lineNumber),
             `${lineNumber}:${columnNumber}`,
-            type === 'error' || type === 'fatal' ? '❌' : '⚠️',
             truncateJingMessage(message),
-          ]);
+          ];
+          if (type === 'error' || type === 'fatal') {
+            errorRows.push(row);
+          } else {
+            warningRows.push(row);
+          }
         }
       });
 
@@ -138,12 +143,16 @@ export async function run(): Promise<void> {
                   lineNumber,
                   columnNumber,
                 });
-                errorRows.push([
+                const row: SummaryTableRow = [
                   makeLink(file, lineNumber),
                   `${lineNumber}:${columnNumber}`,
-                  role === 'warning' ? '⚠️' : '❌',
                   `<small>${text}</small>`,
-                ]);
+                ];
+                if (role === 'warning') {
+                  warningRows.push(row);
+                } else {
+                  errorRows.push(row);
+                }
               }
             }
           );
@@ -173,14 +182,34 @@ export async function run(): Promise<void> {
         );
       }
       core.summary.addList(stats);
-      if (errorRows.length) {
-        errorRows.unshift([
-          { data: 'File', header: true },
-          { data: 'Line:Col', header: true },
-          { data: 'Type', header: true },
-          { data: 'Message', header: true },
-        ]);
-        core.summary.addTable(errorRows.slice(0, ERRLIMIT));
+
+      const header: SummaryTableRow = [
+        { data: 'File', header: true },
+        { data: 'Line:Col', header: true },
+        { data: 'Message', header: true },
+      ];
+      // ERRLIMIT caps the total rows across both tables to keep the summary
+      // under GitHub's size limit; errors get priority.
+      const total = errorRows.length + warningRows.length;
+      const errorSlots = Math.min(errorRows.length, ERRLIMIT);
+      const warningSlots = Math.min(
+        warningRows.length,
+        Math.max(0, ERRLIMIT - errorSlots)
+      );
+
+      if (errorSlots > 0) {
+        core.summary.addHeading('Errors', '3');
+        core.summary.addTable([header, ...errorRows.slice(0, errorSlots)]);
+      }
+      if (warningSlots > 0) {
+        core.summary.addHeading('Warnings', '3');
+        core.summary.addTable([header, ...warningRows.slice(0, warningSlots)]);
+      }
+      if (total > ERRLIMIT) {
+        core.summary.addRaw(
+          `<em>Output truncated: showing ${ERRLIMIT} of ${total} issues.</em>`,
+          true
+        );
       }
     } else {
       core.debug(`No files found. ('${files}')`);

--- a/src/textSummary.ts
+++ b/src/textSummary.ts
@@ -29,32 +29,41 @@ export function formatTextSummary(
     return lines.join('\n') + '\n';
   }
 
-  const header = ['File', 'Line:Col', 'Type', 'Message'];
-  const rows = issues.map((i) => [
+  const errors = issues.filter(
+    (i) => i.type === 'error' || i.type === 'fatal' || i.type === ''
+  );
+  const warnings = issues.filter((i) => i.type === 'warning');
+
+  const toRow = (i: TextSummaryIssue) => [
     i.file,
     `${i.lineNumber}:${i.columnNumber}`,
-    i.type || 'error',
     stripHtml(i.message),
-  ]);
+  ];
 
-  const widths = [0, 1, 2].map((c) =>
-    Math.max(header[c].length, ...rows.map((r) => r[c].length))
-  );
+  const renderTable = (heading: string, rows: string[][]) => {
+    const header = ['File', 'Line:Col', 'Message'];
+    const widths = [0, 1].map((c) =>
+      Math.max(header[c].length, ...rows.map((r) => r[c].length))
+    );
+    const pad = (s: string, w: number) => s + ' '.repeat(w - s.length);
+    const fmt = (row: string[]) =>
+      [pad(row[0], widths[0]), pad(row[1], widths[1]), row[2]].join('  ');
 
-  const pad = (s: string, w: number) => s + ' '.repeat(w - s.length);
-  const fmt = (row: string[]) =>
-    [
-      pad(row[0], widths[0]),
-      pad(row[1], widths[1]),
-      pad(row[2], widths[2]),
-      row[3],
-    ].join('  ');
+    lines.push('');
+    lines.push(heading);
+    lines.push('-'.repeat(heading.length));
+    lines.push(fmt(header));
+    lines.push(fmt(widths.map((w) => '-'.repeat(w)).concat('-'.repeat(20))));
+    for (const row of rows) {
+      lines.push(fmt(row));
+    }
+  };
 
-  lines.push('');
-  lines.push(fmt(header));
-  lines.push(fmt(widths.map((w) => '-'.repeat(w)).concat('-'.repeat(20))));
-  for (const row of rows) {
-    lines.push(fmt(row));
+  if (errors.length) {
+    renderTable('Errors', errors.map(toRow));
+  }
+  if (warnings.length) {
+    renderTable('Warnings', warnings.map(toRow));
   }
 
   return lines.join('\n') + '\n';


### PR DESCRIPTION
Previously all issues were listed in a single table with a Type column. Errors and warnings are now shown in two dedicated tables (errors first), the redundant Type column is dropped, and ERRLIMIT is applied across the combined output with a truncation note when the cap is hit.